### PR TITLE
Game back

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -21,6 +21,7 @@
         "@nestjs/platform-express": "^8.0.0",
         "@nestjs/platform-fastify": "^8.4.4",
         "@nestjs/platform-socket.io": "^8.4.5",
+        "@nestjs/schedule": "^2.0.1",
         "@nestjs/serve-static": "^2.2.2",
         "@nestjs/swagger": "^5.3.0-next.1",
         "@nestjs/typeorm": "^8.0.3",
@@ -1950,6 +1951,20 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/@nestjs/schedule": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-2.0.1.tgz",
+      "integrity": "sha512-NqiCk3P7HDMw55kpefNIzAAQEsP+6dDIXUt4/KQANtAZ+opdLzo8rkzI0j8vDqgYeTh+PKq+V6zwSRjR61xPAQ==",
+      "dependencies": {
+        "cron": "2.0.0",
+        "uuid": "8.3.2"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^6.10.11 || ^7.0.0 || ^8.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0",
+        "reflect-metadata": "^0.1.12"
+      }
     },
     "node_modules/@nestjs/schematics": {
       "version": "8.0.11",
@@ -4265,6 +4280,14 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cron": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-2.0.0.tgz",
+      "integrity": "sha512-RPeRunBCFr/WEo7WLp8Jnm45F/ziGJiHVvVQEBSDTSGu6uHW49b2FOP2O14DcXlGJRLhwE7TIoDzHHK4KmlL6g==",
+      "dependencies": {
+        "luxon": "^1.23.x"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -7860,6 +7883,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
+      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/macos-release": {
@@ -12938,6 +12969,15 @@
         }
       }
     },
+    "@nestjs/schedule": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-2.0.1.tgz",
+      "integrity": "sha512-NqiCk3P7HDMw55kpefNIzAAQEsP+6dDIXUt4/KQANtAZ+opdLzo8rkzI0j8vDqgYeTh+PKq+V6zwSRjR61xPAQ==",
+      "requires": {
+        "cron": "2.0.0",
+        "uuid": "8.3.2"
+      }
+    },
     "@nestjs/schematics": {
       "version": "8.0.11",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-8.0.11.tgz",
@@ -14782,6 +14822,14 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "cron": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-2.0.0.tgz",
+      "integrity": "sha512-RPeRunBCFr/WEo7WLp8Jnm45F/ziGJiHVvVQEBSDTSGu6uHW49b2FOP2O14DcXlGJRLhwE7TIoDzHHK4KmlL6g==",
+      "requires": {
+        "luxon": "^1.23.x"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -17551,6 +17599,11 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "luxon": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
+      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ=="
     },
     "macos-release": {
       "version": "2.5.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,6 +32,7 @@
     "@nestjs/platform-express": "^8.0.0",
     "@nestjs/platform-fastify": "^8.4.4",
     "@nestjs/platform-socket.io": "^8.4.5",
+    "@nestjs/schedule": "^2.0.1",
     "@nestjs/serve-static": "^2.2.2",
     "@nestjs/swagger": "^5.3.0-next.1",
     "@nestjs/typeorm": "^8.0.3",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule } from '@nestjs/config';
 import { UsersModule } from './users/users.module';
 import * as Joi from '@hapi/joi';
 import { AuthModule } from './auth/auth.module';
+import { GamesModule } from './game/games.module';
 
 @Module({
   imports: [
@@ -41,6 +42,7 @@ import { AuthModule } from './auth/auth.module';
     }),
     UsersModule,
     AuthModule,
+    GamesModule
   ],
   controllers: [],
   providers: [],

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,9 +5,11 @@ import { UsersModule } from './users/users.module';
 import * as Joi from '@hapi/joi';
 import { AuthModule } from './auth/auth.module';
 import { GamesModule } from './game/games.module';
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
   imports: [
+    ScheduleModule.forRoot(),
     ConfigModule.forRoot({
       envFilePath: '../.env',
       validationSchema: Joi.object({

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -30,7 +30,7 @@ export class AuthController {
 
         const payload: JwtPayload = { username: req.user['username'], twoFA: false };
         const jwtToken: string = await this.jwtService.sign(payload);
-        res.cookie('jwt', jwtToken, { httpOnly: true, sameSite: 'strict' }); //secure: process.env.MODE !== 'dev'}); //set cookie 
+        res.cookie('jwt', jwtToken, { sameSite: 'strict' }); //secure: process.env.MODE !== 'dev'}); //set cookie //maybe reset httpOnly: true
         res.redirect(process.env.FRONTEND); //back to frontend
     }
 
@@ -51,7 +51,7 @@ export class AuthController {
         }
         const payload: JwtPayload = { username: req.user['username'], twoFA: true };
         const jwtToken: string = await this.jwtService.sign(payload);
-        res.cookie('jwt', jwtToken, { httpOnly: true, sameSite: 'strict' }); //secure: process.env.MODE !== 'dev'}); //set cookie 
+        res.cookie('jwt', jwtToken, { sameSite: 'strict' }); //secure: process.env.MODE !== 'dev'}); //set cookie // maybe reset httpOnly: true
         this.authService.enableTwoFA(req.user);
         return true;
     }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -53,17 +53,21 @@ export class AuthService {
 
   async getUserBySocket(client: Socket): Promise<User> {
     const cookie = client.handshake.headers['cookie'];
-    if (!cookie)
+    if (!cookie) {
+      console.log('cookie error');
       throw new HttpException('cookie absent', 401);
+    }
     const { jwt: token } = parse(cookie);
     const payload: JwtPayload = this.jwtService.verify(token, { secret: process.env.JWT_SECRET });
     const { username, twoFA } = payload;
     const user: User = await this.userService.findUserByUsername(username);
-    if (!user)
+    if (!user) {
       throw new HttpException('User not found', 401);
+    }
     if (user.is2FAEnabled) {
-      if (!twoFA)
+      if (!twoFA) {
         throw new HttpException('Should have validate 2FA', 418);
+      }
     }
     return user;
   }

--- a/backend/src/game/entities/gamehistory.entity.ts
+++ b/backend/src/game/entities/gamehistory.entity.ts
@@ -3,7 +3,7 @@
 
 import { IsNumber } from 'class-validator';
 import { User } from '../../users/entities/user.entity';
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 
 @Entity('gameHistory')
@@ -13,12 +13,12 @@ export class GameHistory {
 	id: number;
 
 	@ApiProperty({ description: 'Winner of match, relation to corresponding user.' })
-	@ManyToOne(() => User, user => user.gamesWon)
-	winner: User;
+	@ManyToOne(() => User, user => user.gamesWon, { nullable: true })
+	winner?: User; //Can be null if user is deleted
 
 	@ApiProperty({ description: 'Looser of match, relation to corresponding user.' })
-	@ManyToOne(() => User, user => user.gamesLost)
-	looser: User;
+	@ManyToOne(() => User, user => user.gamesLost, { nullable: true })
+	looser?: User; //Can be null if user is deleted
 
 	@Column({ type: 'int' })
 	@ApiProperty({ type: Number, description: 'Winner score.' })

--- a/backend/src/game/entities/history.entity.ts
+++ b/backend/src/game/entities/history.entity.ts
@@ -1,2 +1,32 @@
 // For match history in DB table
 // Need : Match id, winner, looser, score winner, score looser, manytomany relation with users
+
+import { IsNumber } from 'class-validator';
+import { User } from '../../users/entities/user.entity';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Entity('gameHistory')
+export class GameHistory {
+	@PrimaryGeneratedColumn()
+	@ApiProperty({ type: Number, description: 'An unique id number attributed to each finished match.' })
+	id: number;
+
+	@ApiProperty({ description: 'Winner of match, relation to corresponding user.' })
+	@ManyToOne(() => User, user => user.gamesWon)
+	winner: User;
+
+	@ApiProperty({ description: 'Looser of match, relation to corresponding user.' })
+	@ManyToOne(() => User, user => user.gamesLost)
+	looser: User;
+
+	@Column({ type: 'int' })
+	@ApiProperty({ type: Number, description: 'Winner score.' })
+	@IsNumber()
+	winnerScore: number;
+
+	@Column({ type: 'int' })
+	@ApiProperty({ type: Number, description: 'Looser score.' })
+	@IsNumber()
+	looserScore: number;	
+}

--- a/backend/src/game/entities/history.entity.ts
+++ b/backend/src/game/entities/history.entity.ts
@@ -1,1 +1,2 @@
-// For match history
+// For match history in DB table
+// Need : Match id, winner, looser, score winner, score looser, manytomany relation with users

--- a/backend/src/game/games.gateway.ts
+++ b/backend/src/game/games.gateway.ts
@@ -38,7 +38,8 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 	}
 
 	async handleDisconnect(client: Socket) {
-		// check if user is in game or in waiting queue
+		// check if user is in game or in waiting queue, send a 'opponentLeft' if
+		// was an opponent
 		if (client.data.user) {
 			await this.usersService.changeStatus(client.data.user, Status.OFFLINE);
 		} else {
@@ -89,11 +90,11 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 					return ;
 				}
 			}
+			client.join(matchId);
 			match.readyUsers.push(client.data.user);
 			if (match.readyUsers.length >= 2) {
 				// start game !
 			}
-			// how to recuperate input ?
 		} catch {
 			return client.disconnect();
 		}

--- a/backend/src/game/games.gateway.ts
+++ b/backend/src/game/games.gateway.ts
@@ -100,6 +100,11 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		}
 	}
 
+	@SubscribeMessage('gameInput')
+	handleGameInput(client: Socket, data: { matchId: string, input: string}) {
+		// Go to game for modification
+	}
+
 	@SubscribeMessage('watchGame')
 	handleWatchGame(client: Socket, user: User) {
 		try {

--- a/backend/src/game/games.gateway.ts
+++ b/backend/src/game/games.gateway.ts
@@ -87,7 +87,7 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
 			const match = matchs.get(matchId);
 			if (!client.data.user) {
 				return client.disconnect();
-			} else if (match === undefined) {
+			} else if (match == undefined) {
 				client.emit('requestError');
 				// throw error ?
 				return ;
@@ -114,7 +114,12 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
 
 	@SubscribeMessage('gameInput')
 	handleGameInput(client: Socket, data: { matchId: string, input: string}) {
-		// Go to game for modification
+		const match = matchs.get(data.matchId);
+		if (match == undefined) {
+			client.emit('requestError');
+			return ;
+		}
+		this.gamesService.playerInput(client, match, data.input);
 	}
 
 	@SubscribeMessage('watchGame')

--- a/backend/src/game/games.module.ts
+++ b/backend/src/game/games.module.ts
@@ -2,9 +2,12 @@ import { Module } from '@nestjs/common';
 import { GamesController } from './games.controller';
 import { GamesService } from './games.service';
 import { GameGateway } from './games.gateway';
+import { UsersModule } from 'src/users/users.module';
+import { AuthService } from '../auth/auth.service';
 
 @Module({
+  imports: [UsersModule],
   controllers: [GamesController],
-  providers: [GamesService, GameGateway]
+  providers: [GamesService, GameGateway, AuthService]
 })
 export class GamesModule {}

--- a/backend/src/game/games.module.ts
+++ b/backend/src/game/games.module.ts
@@ -5,9 +5,12 @@ import { GameGateway } from './games.gateway';
 import { UsersModule } from 'src/users/users.module';
 import { AuthService } from '../auth/auth.service';
 import { PongService } from './pong.service';
+import { GameHistory } from './entities/history.entity';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
 
 @Module({
-  imports: [UsersModule],
+  imports: [UsersModule, TypeOrmModule.forFeature([GameHistory]),],
   controllers: [GamesController],
   providers: [GamesService, GameGateway, AuthService, PongService]
 })

--- a/backend/src/game/games.module.ts
+++ b/backend/src/game/games.module.ts
@@ -5,7 +5,7 @@ import { GameGateway } from './games.gateway';
 import { UsersModule } from 'src/users/users.module';
 import { AuthService } from '../auth/auth.service';
 import { PongService } from './pong.service';
-import { GameHistory } from './entities/history.entity';
+import { GameHistory } from './entities/gamehistory.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 

--- a/backend/src/game/games.module.ts
+++ b/backend/src/game/games.module.ts
@@ -4,10 +4,11 @@ import { GamesService } from './games.service';
 import { GameGateway } from './games.gateway';
 import { UsersModule } from 'src/users/users.module';
 import { AuthService } from '../auth/auth.service';
+import { PongService } from './pong.service';
 
 @Module({
   imports: [UsersModule],
   controllers: [GamesController],
-  providers: [GamesService, GameGateway, AuthService]
+  providers: [GamesService, GameGateway, AuthService, PongService]
 })
 export class GamesModule {}

--- a/backend/src/game/games.service.ts
+++ b/backend/src/game/games.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Socket } from 'socket.io';
 import { UsersService } from '../users/services/users.service';
-import { Match } from './interfaces/match.interface';
+import { Match, State } from './interfaces/match.interface';
 import { Player } from './interfaces/player.interface';
 
 @Injectable()
@@ -63,6 +63,7 @@ export class GamesService {
 			players: matchPlayers,
 			readyUsers: new Array(),
 			watchers: new Array(),
+			state: State.SETTING,
 		};
 		return match;
 	}

--- a/backend/src/game/games.service.ts
+++ b/backend/src/game/games.service.ts
@@ -26,9 +26,18 @@ export class GamesService {
 		for (let currMatch of matchs.values()) {
 			const matchPlayers = currMatch.players;
 			for (let currPlayer of matchPlayers) {
-				if (client == currPlayer.socket || client.data.user.id == currPlayer.user.id) {
+				if (client === currPlayer.socket || client.data.user.id === currPlayer.user.id) {
 					return true;
 				}
+			}
+		}
+		return false;
+	}
+
+	isPlayer(client: Socket, match: Match) : boolean {
+		for(let player of match.players) {
+			if (client.data.user.id === player.user.id) {
+				return true;
 			}
 		}
 		return false;
@@ -52,6 +61,7 @@ export class GamesService {
 		const match: Match = {
 			matchId: matchId,
 			players: matchPlayers,
+			readyUsers: new Array(),
 			watchers: new Array(),
 		};
 		return match;

--- a/backend/src/game/games.service.ts
+++ b/backend/src/game/games.service.ts
@@ -64,6 +64,7 @@ export class GamesService {
 			readyUsers: new Array(),
 			watchers: new Array(),
 			state: State.SETTING,
+			winner: undefined,
 		};
 		return match;
 	}
@@ -71,6 +72,21 @@ export class GamesService {
 	sendToPlayers(match: Match, toSend: string, ...args) {
 		for (let player of match.players) {
 			player.socket.emit(toSend, ...args); // emit more info ?
+		}
+	}
+
+	playerWon(match: Match, player: Player) {
+		if (player.score == 10) {
+			match.winner = player;
+			return true;
+		}
+		return false;
+	}
+
+	scoreUp(match: Match, player: Player) {
+		player.score += 1;
+		if (this.playerWon(match, player) == true) {
+			match.state = State.FINISHED;
 		}
 	}
 }

--- a/backend/src/game/interfaces/match.interface.ts
+++ b/backend/src/game/interfaces/match.interface.ts
@@ -1,8 +1,10 @@
 import { Player } from './player.interface';
 import { Socket } from 'socket.io';
+import { User } from '../../users/entities/user.entity';
 
 export interface Match {
-	matchId: string;
-	players: Array<Player>;
-	watchers: Array<Socket>;
+	matchId:		string;
+	players:		Array<Player>;
+	readyUsers:		Array<User>;
+	watchers: 		Array<Socket>;
 }

--- a/backend/src/game/interfaces/match.interface.ts
+++ b/backend/src/game/interfaces/match.interface.ts
@@ -15,9 +15,7 @@ export interface Match {
 	matchId:		string;
 	players:		Array<Player>;
 	readyUsers:		Array<User>;
-	watchers: 		Array<Socket>;
 	pong:			Pong;
 	state:			State;
 	winner:			Player;
-	interval:		typeof Interval;
 }

--- a/backend/src/game/interfaces/match.interface.ts
+++ b/backend/src/game/interfaces/match.interface.ts
@@ -2,9 +2,17 @@ import { Player } from './player.interface';
 import { Socket } from 'socket.io';
 import { User } from '../../users/entities/user.entity';
 
+export enum State {
+	SETTING = 'SETTING',
+	STARTING = 'STARTING',
+	ONGOING = 'ONGOING',
+	FINISHED = 'FINISHED',
+}
+
 export interface Match {
 	matchId:		string;
 	players:		Array<Player>;
 	readyUsers:		Array<User>;
 	watchers: 		Array<Socket>;
+	state:			State;
 }

--- a/backend/src/game/interfaces/match.interface.ts
+++ b/backend/src/game/interfaces/match.interface.ts
@@ -1,6 +1,8 @@
 import { Player } from './player.interface';
 import { Socket } from 'socket.io';
 import { User } from '../../users/entities/user.entity';
+import { Pong } from './pong.interface';
+import { Interval } from '@nestjs/schedule';
 
 export enum State {
 	SETTING = 'SETTING',
@@ -14,6 +16,8 @@ export interface Match {
 	players:		Array<Player>;
 	readyUsers:		Array<User>;
 	watchers: 		Array<Socket>;
+	pong:			Pong;
 	state:			State;
 	winner:			Player;
+	interval:		typeof Interval;
 }

--- a/backend/src/game/interfaces/match.interface.ts
+++ b/backend/src/game/interfaces/match.interface.ts
@@ -15,4 +15,5 @@ export interface Match {
 	readyUsers:		Array<User>;
 	watchers: 		Array<Socket>;
 	state:			State;
+	winner:			Player;
 }

--- a/backend/src/game/interfaces/pong.interface.ts
+++ b/backend/src/game/interfaces/pong.interface.ts
@@ -1,0 +1,30 @@
+export interface PosOrVec {
+	x: number;
+	y: number;
+}
+
+export interface Ball {
+	pos:	PosOrVec;
+	vel:	PosOrVec;
+	speed:	number;
+	radius:	number;
+}
+
+export interface Paddle {
+	blcPos:	PosOrVec; // blc = bottom left corner
+	width:	number;
+	length:	number;
+}
+
+export interface Field {
+	width:		number;
+	length:		number;
+	offset:	number;
+}
+
+export interface Pong {
+	field:		Field;
+	ball:		Ball;
+	paddleR:	Paddle;
+	paddleL:	Paddle;
+}

--- a/backend/src/game/interfaces/pong.interface.ts
+++ b/backend/src/game/interfaces/pong.interface.ts
@@ -1,3 +1,9 @@
+export enum Point {
+	LEFT = 'leftScore',
+	RIGHT = 'rightScore',
+	NONE = 'none',
+}
+
 export interface PosOrVec {
 	x: number;
 	y: number;

--- a/backend/src/game/pong.service.ts
+++ b/backend/src/game/pong.service.ts
@@ -8,13 +8,13 @@ export class PongService {
 	initPong() : Pong {
 		let field = this.initField();
 		let ball = this.initBall(field);
+		let paddleL = this.initPaddle(field, true);
 		let paddleR = this.initPaddle(field, false);
-		let paddleL = this.initPaddle(field,true);
 		let pong: Pong = {
 			field: field,
 			ball: ball,
-			paddleR: paddleR,
 			paddleL: paddleL,
+			paddleR: paddleR,
 		}
 		return pong;
 	}

--- a/backend/src/game/pong.service.ts
+++ b/backend/src/game/pong.service.ts
@@ -1,0 +1,129 @@
+import { Injectable } from '@nestjs/common';
+import { Player } from './interfaces/player.interface';
+import { PosOrVec, Ball, Paddle, Field, Pong } from './interfaces/pong.interface';
+
+@Injectable()
+export class PongService {
+	constructor() {}
+
+	initPong() {
+		let field = this.initField();
+		let ball = this.initBall(field);
+		let paddleR = this.initPaddle(field, false);
+		let paddleL = this.initPaddle(field,true);
+		let pong: Pong = {
+			field: field,
+			ball: ball,
+			paddleR: paddleR,
+			paddleL: paddleL,
+		}
+		return pong;
+	}
+
+	initField() {
+		let field: Field = {
+			width: 1,
+			length: 1,
+			offset: 1/80,
+		}
+		return field;		
+	}
+
+	initBall(field: Field) {
+		let ball: Ball = {
+			pos: { x: field.length/2, y : field.length/2 },
+			vel: { x: 5, y: 5 },
+			speed: 5,
+			radius: field.length/60
+		}
+		return ball;	
+	}
+
+	initPaddle(field: Field, left: boolean) {
+		const yValue = (left === true) ? (0 + field.length/50) : (field.length - field.length/50);
+		let paddle: Paddle = {
+			blcPos: { x: field.width/2, y: yValue },
+			width: field.width/7,
+			length: field.length/50,
+		}
+		return paddle;
+	}
+
+	resetBall(field: Field, ball: Ball) {
+		ball.pos.x = field.length/2;
+		ball.pos.y = field.width/2;
+		ball.speed = 5;
+		ball.vel.x *= -1;
+	}
+
+	calcBallPos(pong: Pong) {
+		let ball = pong.ball;
+		let field = pong.field;
+
+		ball.pos.x = ball.pos.x + ball.vel.x;
+		ball.pos.y = ball.pos.y + ball.vel.y;
+		if (ball.pos.y + ball.radius < 0 + field.offset) {
+			ball.pos.y = 0 + field.offset;
+			ball.vel.y *= -1;
+		} else if (ball.pos.y + ball.radius > field.width - field.offset) {
+			ball.pos.y = field.width - field.offset;
+			ball.vel.y *= -1;
+		}
+		let collision = false;
+		let paddle = undefined;
+		if (ball.pos.x < field.length/4) { // can affinate this 
+			collision = this.checkCollision(ball, pong.paddleL);
+			paddle = pong.paddleL;
+		} else if (ball.pos.x > ((field.length/4) * 3)) { // can affinate this
+			collision = this.checkCollision(ball, pong.paddleR);
+			paddle = pong.paddleR;
+		}
+		if (collision === true) {
+			this.getBounce(ball, field, paddle);
+		}
+	}
+
+	checkCollision(ball: Ball, paddle: Paddle) {
+		const padTop = paddle.blcPos.y + paddle.width;
+		const padBottom = paddle.blcPos.y;
+		const padLeft = paddle.blcPos.x;
+		const padRight =  paddle.blcPos.x + paddle.length;
+		const ballTop = ball.pos.y + ball.radius;
+		const ballBottom = ball.pos.y - ball.radius;
+		const ballLeft = ball.pos.x - ball.radius;
+		const ballRight = ball.pos.x + ball.radius;
+
+		return (ballRight > padLeft && ballTop < padBottom
+			&& ballLeft < padRight && ballBottom > padTop);
+	}
+	
+	getBounce(ball: Ball, field: Field, paddle: Paddle) {
+		let collidePoint = (ball.pos.y - (paddle.blcPos.y + paddle.width/2)) / paddle.width/2;
+		let bounceAngle = collidePoint * Math.PI/4;
+		let direction = (ball.pos.x < field.length/2) ? 1 : -1;
+		ball.vel.x = direction * ball.speed * Math.cos(bounceAngle);
+		ball.vel.y = ball.speed * Math.sin(bounceAngle);
+		ball.speed += 0.1;
+	}
+
+	updateScore(field: Field, ball: Ball) {
+		if (ball.pos.x - ball.radius < 0 || ball.pos.x + ball.radius > field.length) {
+			this.resetBall(field, ball);
+			//upgrade corresponding score
+		}
+	}
+
+	movePaddle(field: Field, paddle: Paddle, input: string) {
+		if (input === 'UP') {
+			paddle.blcPos.y += field.width/7;
+		} else if (input === 'DOWN') {
+			paddle.blcPos.y -= field.width/7;
+		}
+		if (paddle.blcPos.y + paddle.width > field.width + field.offset) {
+			paddle.blcPos.y = field.width - field.offset;
+		} else if (paddle.blcPos.y < 0 + field.offset) {
+			paddle.blcPos.y = 0 + field.offset;
+		}
+	}
+
+}

--- a/backend/src/game/pong.service.ts
+++ b/backend/src/game/pong.service.ts
@@ -1,12 +1,11 @@
 import { Injectable } from '@nestjs/common';
-import { Player } from './interfaces/player.interface';
-import { PosOrVec, Ball, Paddle, Field, Pong } from './interfaces/pong.interface';
+import { Point, Ball, Paddle, Field, Pong } from './interfaces/pong.interface';
 
 @Injectable()
 export class PongService {
 	constructor() {}
 
-	initPong() {
+	initPong() : Pong {
 		let field = this.initField();
 		let ball = this.initBall(field);
 		let paddleR = this.initPaddle(field, false);
@@ -20,7 +19,7 @@ export class PongService {
 		return pong;
 	}
 
-	initField() {
+	initField() : Field {
 		let field: Field = {
 			width: 1,
 			length: 1,
@@ -29,7 +28,7 @@ export class PongService {
 		return field;		
 	}
 
-	initBall(field: Field) {
+	initBall(field: Field) : Ball {
 		let ball: Ball = {
 			pos: { x: field.length/2, y : field.length/2 },
 			vel: { x: 5, y: 5 },
@@ -39,7 +38,7 @@ export class PongService {
 		return ball;	
 	}
 
-	initPaddle(field: Field, left: boolean) {
+	initPaddle(field: Field, left: boolean) : Paddle {
 		const yValue = (left === true) ? (0 + field.length/50) : (field.length - field.length/50);
 		let paddle: Paddle = {
 			blcPos: { x: field.width/2, y: yValue },
@@ -47,13 +46,6 @@ export class PongService {
 			length: field.length/50,
 		}
 		return paddle;
-	}
-
-	resetBall(field: Field, ball: Ball) {
-		ball.pos.x = field.length/2;
-		ball.pos.y = field.width/2;
-		ball.speed = 5;
-		ball.vel.x *= -1;
 	}
 
 	calcBallPos(pong: Pong) {
@@ -83,7 +75,14 @@ export class PongService {
 		}
 	}
 
-	checkCollision(ball: Ball, paddle: Paddle) {
+	resetBall(field: Field, ball: Ball) {
+		ball.pos.x = field.length/2;
+		ball.pos.y = field.width/2;
+		ball.speed = 5;
+		ball.vel.x *= -1;
+	}
+
+	checkCollision(ball: Ball, paddle: Paddle) : boolean {
 		const padTop = paddle.blcPos.y + paddle.width;
 		const padBottom = paddle.blcPos.y;
 		const padLeft = paddle.blcPos.x;
@@ -97,7 +96,7 @@ export class PongService {
 			&& ballLeft < padRight && ballBottom > padTop);
 	}
 	
-	getBounce(ball: Ball, field: Field, paddle: Paddle) {
+	getBounce(ball: Ball, field: Field, paddle: Paddle) : void {
 		let collidePoint = (ball.pos.y - (paddle.blcPos.y + paddle.width/2)) / paddle.width/2;
 		let bounceAngle = collidePoint * Math.PI/4;
 		let direction = (ball.pos.x < field.length/2) ? 1 : -1;
@@ -106,14 +105,18 @@ export class PongService {
 		ball.speed += 0.1;
 	}
 
-	updateScore(field: Field, ball: Ball) {
-		if (ball.pos.x - ball.radius < 0 || ball.pos.x + ball.radius > field.length) {
+	getScore(field: Field, ball: Ball): Point {
+		if (ball.pos.x - ball.radius < 0) {
 			this.resetBall(field, ball);
-			//upgrade corresponding score
+			return Point.RIGHT;
+		} else if (ball.pos.x + ball.radius > field.length) {
+			this.resetBall(field, ball);
+			return Point.LEFT;
 		}
+		return Point.NONE;
 	}
 
-	movePaddle(field: Field, paddle: Paddle, input: string) {
+	movePaddle(field: Field, paddle: Paddle, input: string) : void {
 		if (input === 'UP') {
 			paddle.blcPos.y += field.width/7;
 		} else if (input === 'DOWN') {
@@ -125,5 +128,4 @@ export class PongService {
 			paddle.blcPos.y = 0 + field.offset;
 		}
 	}
-
 }

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -1,11 +1,12 @@
 import { IsEmail, IsNumber, IsAlphanumeric } from 'class-validator';
 import { Entity, PrimaryGeneratedColumn, Column, BeforeInsert, BeforeUpdate, OneToOne,
-		JoinColumn } from 'typeorm';
+		JoinColumn, OneToMany } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { Status } from '../../common/enums/status.enum';
 import * as crypto from 'crypto';
 import { Avatar } from './avatar.entity';
 import { Exclude } from 'class-transformer';
+import { GameHistory } from '../../game/entities/history.entity';
 
 @Entity('users') // sql table will be name 'users'
 export class User {
@@ -58,9 +59,13 @@ export class User {
 	@ApiProperty({ type: Number, description: 'Elo score, based on Elo chess system and modified after each match.'})
 	eloScore: number;
 
-	// For game history and stats:
-	//@OneToMany(() => Game (game: Game) => game.player) // how to select which player ?
-	//matchHistory: Game; 
+	@ApiProperty({ description: 'History of games won in relation with corresponding gameHistory entity.'})
+	@OneToMany(() => GameHistory,  game => game.winner) // how to select which player ?
+	gamesWon: GameHistory; 
+
+	@ApiProperty({ description: 'History of games lost in relation with corresponding gameHistory entity.'})
+	@OneToMany(() => GameHistory,  game => game.looser) // how to select which player ?
+	gamesLost: GameHistory; 
 
 	// Source of encryption : https://gist.github.com/vlucas/2bd40f62d20c1d49237a109d491974eb
 	@BeforeInsert()

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -6,7 +6,7 @@ import { Status } from '../../common/enums/status.enum';
 import * as crypto from 'crypto';
 import { Avatar } from './avatar.entity';
 import { Exclude } from 'class-transformer';
-import { GameHistory } from '../../game/entities/history.entity';
+import { GameHistory } from '../../game/entities/gamehistory.entity';
 
 @Entity('users') // sql table will be name 'users'
 export class User {
@@ -40,11 +40,11 @@ export class User {
 
 	@Column({ type: 'text', nullable: true })
 	@ApiProperty({ type: String, description: 'User personal 2FA Secret (optional field)'})
-  	public twoFASecret?: string;
+  	twoFASecret?: string;
 	
 	@Column({ type: 'boolean', default: false })
 	@ApiProperty({ type: String, description: 'User as activate 2FA)'})
-  	public is2FAEnabled: boolean;
+  	is2FAEnabled: boolean;
 
 	@Column({ type: 'int', array: true, default: {} })
 	@ApiProperty({ type: [Number], description: 'User friends, identified by unique ids inside an array.'})
@@ -60,12 +60,12 @@ export class User {
 	eloScore: number;
 
 	@ApiProperty({ description: 'History of games won in relation with corresponding gameHistory entity.'})
-	@OneToMany(() => GameHistory,  game => game.winner) // how to select which player ?
-	gamesWon: GameHistory; 
+	@OneToMany(() => GameHistory,  game => game.winner, { cascade: true })
+	gamesWon: GameHistory[]; 
 
 	@ApiProperty({ description: 'History of games lost in relation with corresponding gameHistory entity.'})
-	@OneToMany(() => GameHistory,  game => game.looser) // how to select which player ?
-	gamesLost: GameHistory; 
+	@OneToMany(() => GameHistory,  game => game.looser, { cascade: true })
+	gamesLost: GameHistory[]; 
 
 	// Source of encryption : https://gist.github.com/vlucas/2bd40f62d20c1d49237a109d491974eb
 	@BeforeInsert()

--- a/backend/src/users/services/users.service.ts
+++ b/backend/src/users/services/users.service.ts
@@ -51,8 +51,6 @@ export class UsersService {
 
 	async retrieveOrCreateUser(createUserDto: CreateUserDto) {
 		const { username, email } = createUserDto;
-		console.log(username);
-		console.log(email);
 		let nickname = username;
 		let user = await this.userRepository.findOne({ username: username, email: email });
 		if (user) {

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,7 +1,7 @@
 import { UsersService } from './services/users.service';
 import { Body, Controller, Param, Post, Get, ClassSerializerInterceptor, 
 		UseInterceptors, UseGuards, Req, Query, Patch, Res, UploadedFile,
-		Delete, ParseIntPipe, HttpException, HttpStatus } from '@nestjs/common';
+		Delete, ParseIntPipe, HttpException, HttpStatus, Logger } from '@nestjs/common';
 import { CreateUserDto, UpdateUserDto } from './user.dto';
 import { ApiBadRequestResponse, ApiCreatedResponse, ApiTags,
 		ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiForbiddenResponse } from '@nestjs/swagger';
@@ -36,6 +36,8 @@ export class UsersController {
 	constructor(private readonly usersService: UsersService,
 		private readonly avatarsService: AvatarsService) {}
 
+	private logger: Logger = new Logger('UserController');
+
 	@Get()
 	@UseGuards(AuthGuard('jwt'), AuthUser)
 	/** Swagger **/
@@ -44,6 +46,7 @@ export class UsersController {
 	@ApiForbiddenResponse({ description: 'Only logged users can access it.'})
 	/** End of swagger **/	
 	findAllUsers() : Promise<User[]> {
+		this.logger.log('Get() route called');
 		return this.usersService.findAllUsers();
 	}
 
@@ -52,11 +55,12 @@ export class UsersController {
 	/** Swagger **/
 	@ApiOperation({summary: 'Check if user is logged through token.'})
 	@ApiOkResponse({ description: 'Return true if the User is properly logged else: \
-	 reutrn 401 if the token is absent and 418 if it dosent make tea.', type: Boolean })
+	 return 401 if the token is absent and 418 if it doesn\'t make tea.', type: Boolean })
 	@ApiNotFoundResponse({ description: 'Not found.' })
 	@ApiForbiddenResponse({ description: 'Only logged users can access it.'})
 	/** End of swagger **/
 	logged(@Req() req: RequestUser): boolean {
+		this.logger.log('Get(\'logged\') route called by user ' + req.user.username + ' (username)');
 		const user: User = req.user;
 		if (user.is2FAEnabled == true) {
 			const token = req.cookies['jwt'];
@@ -75,6 +79,7 @@ export class UsersController {
 	@ApiForbiddenResponse({ description: 'Only logged users can access it.'})
 	/** End of swagger **/
 	currentUser(@Req() req: RequestUser) : Promise<Partial<User>> {
+		this.logger.log('Get(\'currentUser\') route called by user ' + req.user.username + ' (username)');
 		const user: User = req.user;
 		return this.usersService.currentUser(user);
 	}
@@ -87,6 +92,7 @@ export class UsersController {
 	@ApiForbiddenResponse({ description: 'Only logged users can access it.'})
 	/** End of swagger **/
 	userInfo(@Query('username') username: string): Promise<Partial<User>> {
+		this.logger.log('Get(\'userInfo\') route called for user ' + username + ' (username)');
 		return this.usersService.userInfo(username);
 	}
 
@@ -98,6 +104,7 @@ export class UsersController {
 	@ApiForbiddenResponse({ description: 'Only logged users can access it.'})
 	/** End of swagger **/
 	getPartialUserInfo(@Query('userId') userId: string): Promise<Partial<User>> {
+		this.logger.log('Get(\'partialInfo\') route called for user ' + userId + ' (user id)');
 		return this.usersService.getPartialUserInfo(userId);
 	}
 
@@ -110,6 +117,7 @@ export class UsersController {
 	@ApiForbiddenResponse({ description: 'Only logged users can access it.'})
 	/** End of swagger **/
 	findSpecificUser(@Param('id') id: number) : Promise<User> {
+		this.logger.log('Get(\':id\') route.');
 		return this.usersService.findUserById('' + id);
 	}
 
@@ -122,6 +130,7 @@ export class UsersController {
 	@ApiForbiddenResponse({ description: 'Only logged users can access it.'})
 	/** End of swagger **/
 	async getAvatar(@Param('id', ParseIntPipe) id: number, @Res({ passthrough: true}) res) {
+		this.logger.log('Get(\'getAVatar/:id\') route called.');
 		return await this.usersService.getAvatarByAvatarId(id, res);
 	}
 
@@ -133,7 +142,7 @@ export class UsersController {
 	@ApiBadRequestResponse()
 	/** End of swagger **/
 	retrieveOrCreateUser(@Body() createUserDto: CreateUserDto) : Promise <User> {
-		console.log(createUserDto);
+		this.logger.log('Post(\'getOrRegister\') route called for user ' + createUserDto.username + ' (username)');
 		return this.usersService.retrieveOrCreateUser(createUserDto);
 	}
 
@@ -145,6 +154,7 @@ export class UsersController {
 	@ApiForbiddenResponse({ description: 'Only logged users can access it.'})
 	/** End of swagger **/
 	uploadAvatar(@Req() req: RequestUser, @UploadedFile() file: Express.Multer.File) {
+		this.logger.log('Post(\'uploadAvatar\') route called by user ' + req.user.username + ' (username)');
 		return this.usersService.addAvatar(req.user, file.originalname, file.buffer);
 	}
 
@@ -155,6 +165,7 @@ export class UsersController {
 	@ApiForbiddenResponse({ description: 'Only logged users can access it.'})
 	/** End of swagger **/
 	set2FASecret(@Req() req: RequestUser, @Body('secret') secret: string) {
+		this.logger.log('Post(\'secret\') route called by user ' + req.user.username + ' (username)');
 		return this.usersService.setTwoFASecret(req.user, secret);
 	}
 	
@@ -166,6 +177,7 @@ export class UsersController {
 	@ApiForbiddenResponse({ description: 'Only logged users can access it.'})
 	/** End of swagger **/
 	async updateUser(@Body() updateUser: UpdateUserDto, @Req() req: RequestUser, @Res({passthrough: true}) res: Response) {
+		this.logger.log('Post(\'settings\') route called by user ' + req.user.username + ' (username)');
 		return this.usersService.updateUser(req.user, updateUser);
 	}
 
@@ -176,6 +188,7 @@ export class UsersController {
 	@ApiCreatedResponse({ description: 'The user has been successfully login.', type : User })
 	/** End of swagger **/
 	async loginUser(@Req() req: RequestUser)  {
+		this.logger.log('Patch(\'login\') route called by user ' + req.user.username + ' (username)');
 		return this.usersService.changeStatus(req.user, Status.ONLINE);
 	}
 	
@@ -186,6 +199,7 @@ export class UsersController {
 	@ApiCreatedResponse({ description: 'The user has been successfully logout.' })
 	/** End of swagger **/
 	async logoutUser(@Req() req: RequestUser, @Res({ passthrough: true }) res: Response) {
+		this.logger.log('Patch(\'logout\') route called by user ' + req.user.username + ' (username)');
 		this.usersService.changeStatus(req.user, Status.OFFLINE);
 		res.clearCookie('jwt');
 	}
@@ -196,6 +210,7 @@ export class UsersController {
 	@ApiOkResponse({ description: 'User successfully deleted.', type: User })
 	/** End of swagger **/
 	async removeUser(@Req() req: RequestUser, @Res({ passthrough: true }) res: Response) {
+		this.logger.log('Delete(\'deleteAccount\') route called by user ' + req.user.username + ' (username)');
 		this.usersService.removeUser(req.user);
 		res.clearCookie('jwt');
 	}


### PR DESCRIPTION
Some stuff for websockets connection for game.

For now it contains mostly a queue system to match opponents by order of arrival. Set up a match, and wait for both opponents to 'accept' the game (just to be sure they are ready to play and didn't went afk).

The actual game part is not coded yet.

Please, bear in mind that's it's difficult to test without a front part, so many stuff may not be functional as it is. 

Basics schema of gateway from backend
-----
User enters websocket if he want to play or watch a game.

Schema for play: `joinGame` request + `acceptGame` request
Schema for watch: `watchGame` request + `followGame` request.

For more details on request, see bellow.

Special case of invitation from chat part:
**_If possible_** Users must join game websocket when hitting the 'invit to game' button. Then the client sending the invitation must call `invitToGame` with it's socket and opponent socket as arguments.



Details of gateway routes/requests
-----

- `joinGame` => When a client wants to join a game (vs watch a game), he's then put in queue or set with an opponent if queue.length >= 2. When a match is made, and each client is set with an opponent, both clients receive a `foundMatch` message `+ the matchId` which is a unique id string. 
A timeout until 10 secondes is set, and if both users don't accept the match, the match is aborted and they receive a `foundMatch` message followed by `null`. As at least one of the user may be AFK, they can't be send back to queue so they may need to join again the queue by sending a new `joinGame` request.


- `acceptGame` + args : `{ matchId: string }` =>  When a client accept the match (to be sure he is not AFK), the game can then start when both opponent accepted the game. They join a socket.io room identified by the matchId. If both users accepted game/are ready, the game can start. 
First player registered in the `match.players` user will be left player and receive a `beReady` message followed by `left` (it's position) + `matchId` + `nickname of opponent`. An equivalent message will be receive by second player, with `right` instead of left. A countdown is set from 3 to 0, and each second users received a `countdown` `3 to 1 in string` `matchId` message. When countdown is set at 0, they receive a `gameStarting` `matchId` message.
Game calculations are updated each 50 ms. 
Those updates are transmitted to client through `gameUpdate` `matchId` `{ ball : { pos: { x , y }, radius }}` `{ left paddle: { bottom left corner pos : { x , y }, width, length }, right paddle : { -same as left paddle- }}` messages. 
If a score modification is made, clients receive a `score` `matchId` `score left player` `score right player` message.
If a player hit 10 points, it's a win ! Clients receive `endGame` `matchId` `winner nickname` message.
Then, all users connected to the socket.io room (players but also watchers) leave the room.
_More to follow_


- `gameInput` + args: `{ matchId: string + input: string }` => To receive if paddle move up or down. Input must either be `UP` or `DOWN` string. **_Right now, it doesn't call for a game update, as updates are made each 50ms, but I can be set if the game is not smooth enough_**


- `watchGame` => When a client want to watch a game. Client is added to an array of watchers. A list of ongoing game is sent to him with the following message for each game : `ongoingGame` `matchId` `nickname of left player` `nickname of right player`.
Before and after list sending, a `newList` and a `endList` messages are send.
Each time a new game is in ongoing state or a game is finished, a new list will be sent to all watchers currently not looking at a game.


- `followGame` + args: `{ matchId: string }` => Request for a watcher to follow a specific game indentified by `matchId`. The client then join the same socket.io room as match players and receive the same info as them.


- `invitToGame` + args: `{ opponent: Socket }` => Create a game instance for invitation system through chat. Users must be connected beforehand and request must contains opponent socket. _I'm not sure if it's possible ? This may need some work._



Non requestable gateway function :

`handleConnection` => Called upon websocket connection, it retrieve user corresponding to client socket through cookie (cf authService.getUserBySocket(client))

`handleDisconnect` => Called upon websocket deconnection.


Pong algorithm
----
(Sorry for the bad drawing, but I'm not used to Gimp for image edition)

![IMG_20220525_181512~2](https://user-images.githubusercontent.com/67599180/170309959-5be429ca-a27a-4410-929b-f898bde5c4d0.jpg)
/!\ Image not to scale

Quick explanation : 
It calculates ball position according to it's position and velocity (speed * direction). 
When a ball hit a paddle, it'll bounce with an angle dependent on where the paddle was hit. If it's in the middle, the angle is 0, if it's on an edge, the angle is 45°.

Right now the value are normalized (from 0 to 1) according to field length and width (both set at 1).

Paddle position in space is calculated according its length, width, and bottom left corner position.
Ball position in space is calculated according its center position and radius.
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          